### PR TITLE
75 Improvements for comprehension in debug view

### DIFF
--- a/src/Fluent.Calculations.DotNetGraph/CalculationDotGraphRenderer.cs
+++ b/src/Fluent.Calculations.DotNetGraph/CalculationDotGraphRenderer.cs
@@ -37,7 +37,7 @@ public class CalculationDotGraphRenderer
         {
             DotNodeBlock newBlock = CreateBlockByType(value);
 
-            if (value.IsParameter)
+            if (value.Origin == ValueOriginType.Parameter || value.Origin == ValueOriginType.Constant)
                 targerParametersCluster.Add(newBlock.LastNode);
             else
             {

--- a/src/Fluent.Calculations.DotNetGraph/DotNetGraphBuilderDefault.cs
+++ b/src/Fluent.Calculations.DotNetGraph/DotNetGraphBuilderDefault.cs
@@ -66,21 +66,21 @@ namespace Fluent.Calculations.DotNetGraph
             return node;
         }
 
-        private string ShapyByValueType(IValue value)
+        private static string ShapyByValueType(IValue value)
         {
-            if (value.IsOutput)
+            if (value.Origin == ValueOriginType.Result)
                 return "ellipse";
 
-            if (value.IsParameter)
+            if (value.Origin == ValueOriginType.Parameter)
                 return "parallelogram";
 
             return "Rectangle";
         }
 
-        private string ColorByValueType(IValue value) => value.IsOutput ?
+        private static string ColorByValueType(IValue value) => value.Origin == ValueOriginType.Result ?
                 "#7ffac2" : "skyblue";
 
-        private string ToExpressionNodeHtml(IValue value)
+        private static string ToExpressionNodeHtml(IValue value)
         {
             return $@"<table border=""0"">
                     <tr><td align=""center""><b>{Html(value.Name)}</b></td></tr>
@@ -88,14 +88,14 @@ namespace Fluent.Calculations.DotNetGraph
                 </table>";
         }
 
-        private string ToConstantNodeHtml(IValue value)
+        private static string ToConstantNodeHtml(IValue value)
         {
             return $@"<table border=""0"">
                     <tr><td align=""left""><b>{Html(value.Name)}</b></td></tr>
                     <tr><td align=""center"">{value.ValueToString()}</td></tr>
                 </table>";
         }
-        private string ToValueNodeHtml(IValue value)
+        private static string ToValueNodeHtml(IValue value)
         {
             return $@"<table border=""0"">
                     <tr><td align=""center""><b>{Html(value.Name)}</b></td></tr>
@@ -104,7 +104,7 @@ namespace Fluent.Calculations.DotNetGraph
         }
 
 
-        string Html(string value) => HttpUtility.HtmlEncode(value);
+        private static string Html(string value) => HttpUtility.HtmlEncode(value);
 
         public DotEdge CreateSolidEdge(DotNode firstNode, DotNode lastNode) =>
             new DotEdge().From(firstNode).To(lastNode).WithPenWidth(2);

--- a/src/Fluent.Calculations.Primitives.Tests/BaseTypes/ValueTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/BaseTypes/ValueTests.cs
@@ -24,6 +24,6 @@ public class ValueTests
 public class FakeInheritedValue : Value
 {
     public FakeInheritedValue(MakeValueArgs args) : base(args) { }
-    public override IValue Default => new FakeInheritedValue(MakeValueArgs.Compose(StringConstants.NaN, ExpressionNode.None, 0));
+    public override IValue GetDefault() => new FakeInheritedValue(MakeValueArgs.Compose(StringConstants.NaN, ExpressionNode.None, 0));
     public override IValue MakeOfThisType(MakeValueArgs args) => new FakeInheritedValue(args);
 }

--- a/src/Fluent.Calculations.Primitives.Tests/Collections/FakeValue.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/Collections/FakeValue.cs
@@ -17,7 +17,7 @@ namespace Fluent.Calculations.Primitives.Tests.Collections
 
         public TagsCollection Tags { get; set; }
 
-        public IValue Default => new FakeValue();
+        public IValue GetDefault() => new FakeValue();
 
         public IValue MakeOfThisType(MakeValueArgs args) => new FakeValue
         {

--- a/src/Fluent.Calculations.Primitives.Tests/Collections/FakeValue.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/Collections/FakeValue.cs
@@ -9,13 +9,11 @@ namespace Fluent.Calculations.Primitives.Tests.Collections
 
         public decimal Primitive { get; set; }
 
-        public bool IsParameter { get; set; }
-
-        public bool IsOutput { get; set; }
-
         public ExpressionNode Expression { get; set; }
 
         public TagsCollection Tags { get; set; }
+
+        public ValueOriginType Origin => ValueOriginType.Parameter;
 
         public IValue GetDefault() => new FakeValue();
 

--- a/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/Money.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/Money.cs
@@ -25,6 +25,6 @@ public class Money : Number
 
     public override IValue MakeOfThisType(MakeValueArgs args) => new Money(args, Currency);
 
-    public override IValue Default => new Money(Currency.None);
+    public override IValue GetDefault() => new Money(Currency.None);
 }
 

--- a/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ConstantsAndConditionsTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ConstantsAndConditionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Fluent.Calculations.DotNetGraph;
-using Fluent.Calculations.Primitives.BaseTypes;
+﻿using Fluent.Calculations.Primitives.BaseTypes;
 using FluentAssertions;
 
 namespace Fluent.Calculations.Primitives.Tests.Integration

--- a/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ConstantsComparisionAndConditionalTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ConstantsComparisionAndConditionalTests.cs
@@ -33,8 +33,8 @@ namespace Fluent.Calculations.Primitives.Tests.Integration
 
         Condition Comparison => Evaluate(() => ConstantOne > ConstantTwo);
 
-        Number Condtitional => Evaluate(() => Comparison ? ConstantOne : ConstantTwo);
+        Number Conditional => Evaluate(() => Comparison ? ConstantOne : ConstantTwo);
 
-        public override Number Return() => Condtitional;
+        public override Number Return() => Conditional;
     }
 }

--- a/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ConstantsComparisionAndConditionalTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ConstantsComparisionAndConditionalTests.cs
@@ -16,7 +16,8 @@ namespace Fluent.Calculations.Primitives.Tests.Integration
 
             Number result = calculation.ToResult();
 
-            result.Should().NotBeNull();
+            result.Primitive.Should().Be(3);
+            result.Name.Should().Be("Conditional");
         }
     }
 

--- a/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsCollection.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsCollection.cs
@@ -1,6 +1,9 @@
 ﻿namespace Fluent.Calculations.Primitives.BaseTypes;
 using System.Collections;
+using System.Diagnostics;
 
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(ArgumentsCollectionDebugView))]
 public sealed class ArgumentsCollection : IReadOnlyCollection<IValue>
 {
     private readonly List<IValue> items;

--- a/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsCollectionDebugView.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsCollectionDebugView.cs
@@ -1,0 +1,14 @@
+﻿namespace Fluent.Calculations.Primitives.BaseTypes
+{
+    using System.Diagnostics;
+
+    public class ArgumentsCollectionDebugView
+    {
+        private readonly ArgumentsCollection arguments;
+
+        public ArgumentsCollectionDebugView(ArgumentsCollection arguments) => this.arguments = arguments;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public IValue[] Arguments => arguments.ToArray();
+    }
+}

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Condition.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Condition.cs
@@ -1,9 +1,11 @@
 ﻿namespace Fluent.Calculations.Primitives.BaseTypes;
 using Fluent.Calculations.Primitives.Expressions;
 using Fluent.Calculations.Primitives.Utils;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
+[DebuggerDisplay("Name = {Name}, Value = {IsTrue}")]
 public sealed class Condition : Value,
     IEqualityOperators<Condition, Condition, Condition>,
     IBitwiseOperators<Condition, Condition, Condition>

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Condition.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Condition.cs
@@ -20,7 +20,7 @@ public sealed class Condition : Value,
 
     public bool IsTrue => Primitive > 0;
 
-    public override IValue Default => False();
+    public override IValue GetDefault() => False();
 
     public static bool operator true(Condition condition) => condition.IsTrue;
 

--- a/src/Fluent.Calculations.Primitives/BaseTypes/IValue.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/IValue.cs
@@ -17,7 +17,7 @@ public interface IValue
 
     IValue MakeOfThisType(MakeValueArgs args);
 
-    IValue Default { get; }
+    IValue GetDefault();
 
     string ValueToString();
 }

--- a/src/Fluent.Calculations.Primitives/BaseTypes/IValue.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/IValue.cs
@@ -7,9 +7,7 @@ public interface IValue
 
     decimal Primitive { get; }
 
-    bool IsParameter { get; }
-
-    bool IsOutput { get; }
+    ValueOriginType Origin { get; }
 
     ExpressionNode Expression { get; }
 

--- a/src/Fluent.Calculations.Primitives/BaseTypes/MakeValueArgs.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/MakeValueArgs.cs
@@ -11,19 +11,22 @@ public class MakeValueArgs
 
     public decimal PrimitiveValue { get; private set; }
 
-    public bool IsParameter { get; private set; }
+    public ValueOriginType Origin { get; private set; }
 
     public ArgumentsCollection Arguments { get; private set; } = ArgumentsCollection.Empty;
 
     public TagsCollection Tags { get; private set; } = TagsCollection.Empty;
 
     internal static MakeValueArgs Compose(string name, ExpressionNode expression, decimal primitiveValue) =>
-        new MakeValueArgs
+        Compose(name, expression, primitiveValue, ValueOriginType.Constant);
+
+    internal static MakeValueArgs Compose(string name, ExpressionNode expression, decimal primitiveValue, ValueOriginType origin) =>
+        new()
         {
             Name = name,
             Expression = expression,
             PrimitiveValue = primitiveValue,
-            IsParameter = false
+            Origin = origin
         };
 
     internal static object Compose(string fieldName, ExpressionNode expressionNode, object primitiveValue)

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Number.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Number.cs
@@ -24,7 +24,7 @@ public class Number : Value,
 
     public static implicit operator Number(decimal primitiveValue) => Number.Of(primitiveValue);
 
-    public static Number Zero => new() { IsParameter = true };
+    public static Number Zero => new() { Origin = ValueOriginType.Constant };
 
     public static Number Of(decimal primitiveValue, [CallerMemberName] string fieldName = "") =>
         new(MakeValueArgs.Compose(fieldName, new ExpressionNode($"{primitiveValue}", ExpressionNodeType.Constant), primitiveValue));

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Number.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Number.cs
@@ -77,7 +77,7 @@ public class Number : Value,
 
     public override IValue MakeOfThisType(MakeValueArgs args) => new Number(args);
 
-    public override IValue Default => Zero;
+    public override IValue GetDefault()=> Zero;
 
     public override bool Equals(object? obj) => Equals(obj as IValue);
 

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Tag.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Tag.cs
@@ -1,5 +1,8 @@
-﻿namespace Fluent.Calculations.Primitives.BaseTypes;
+﻿using System.Diagnostics;
 
+namespace Fluent.Calculations.Primitives.BaseTypes;
+
+[DebuggerDisplay("{Name}")]
 public sealed class Tag
 {
     public required string Name { get; init; }

--- a/src/Fluent.Calculations.Primitives/BaseTypes/TagsCollection.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/TagsCollection.cs
@@ -1,6 +1,8 @@
 ﻿namespace Fluent.Calculations.Primitives.BaseTypes;
 using System.Collections;
+using System.Diagnostics;
 
+[DebuggerDisplay("Count = {Count}")]
 public sealed class TagsCollection : IReadOnlyCollection<Tag>
 {
     private readonly List<Tag> items;

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Value.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Value.cs
@@ -11,9 +11,7 @@ public abstract class Value : IValue, IOrigin
 
     public decimal Primitive { get; init; }
 
-    public bool IsParameter { get; protected set; }
-
-    public bool IsOutput { get; private set; }
+    public ValueOriginType Origin { get; protected set; }
 
     public TagsCollection Tags { get; init; }
 
@@ -29,7 +27,7 @@ public abstract class Value : IValue, IOrigin
         Name = value.Name;
         Expression = value.Expression;
         Primitive = value.Primitive;
-        IsParameter = value.IsParameter;
+        Origin = value.Origin;
         Tags = value.Tags;
     }
 
@@ -37,7 +35,7 @@ public abstract class Value : IValue, IOrigin
     {
         Name = createValueArgs.Name;
         Primitive = createValueArgs.PrimitiveValue;
-        IsParameter = createValueArgs.IsParameter;
+        Origin = createValueArgs.Origin;
         Expression = createValueArgs.Expression;
         Tags = createValueArgs.Tags;
     }
@@ -57,14 +55,14 @@ public abstract class Value : IValue, IOrigin
 
     IValue IOrigin.AsResult()
     {
-        IsOutput = true;
+        Origin = ValueOriginType.Result;
         return this;
     }
 
     void IOrigin.MarkAsParameter(string name)
     {
         Name = name;
-        IsParameter = true;
+        Origin = ValueOriginType.Parameter;
     }
 
     public bool Equals(IValue? value) => value != null && Primitive.Equals(value.Primitive);

--- a/src/Fluent.Calculations.Primitives/BaseTypes/Value.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/Value.cs
@@ -1,6 +1,8 @@
 ﻿namespace Fluent.Calculations.Primitives.BaseTypes;
 using Fluent.Calculations.Primitives.Expressions;
+using System.Diagnostics;
 
+[DebuggerDisplay("Name = {Name}, Value = {Primitive}")]
 public abstract class Value : IValue, IOrigin
 {
     public string Name { get; private set; }
@@ -42,7 +44,7 @@ public abstract class Value : IValue, IOrigin
 
     public abstract IValue MakeOfThisType(MakeValueArgs args);
 
-    public abstract IValue Default { get; }
+    public abstract IValue GetDefault();
 
     public ResultType HandleBinaryOperation<ResultType, ResultPrimitiveType>(
         IValue right,
@@ -50,6 +52,7 @@ public abstract class Value : IValue, IOrigin
         string operatorName) where ResultType : IValue, new() =>
         BinaryOperatorHandler.Handle<ResultType, ResultPrimitiveType>(this, right, expressionFunc, operatorName, ExpressionNodeType.BinaryExpression);
 
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     bool IOrigin.IsSet => !Name.IsNaNOrNull();
 
     IValue IOrigin.AsResult()

--- a/src/Fluent.Calculations.Primitives/BaseTypes/ValueOriginType.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/ValueOriginType.cs
@@ -1,0 +1,10 @@
+﻿namespace Fluent.Calculations.Primitives.BaseTypes;
+
+public enum ValueOriginType
+{
+    NotSet,
+    Parameter,
+    Constant,
+    Evaluation,
+    Result,
+}

--- a/src/Fluent.Calculations.Primitives/Collections/Values.cs
+++ b/src/Fluent.Calculations.Primitives/Collections/Values.cs
@@ -23,13 +23,14 @@
             Expression.UpdateBody(ComposeExpressionBody(Expression.Arguments.Count));
             Primitive += value.Primitive;
             Name = fieldName;
+            Origin = value.Origin;
         }
 
         protected Values(MakeValueArgs createValueArgs)
         {
             Name = createValueArgs.Name;
             Primitive = createValueArgs.PrimitiveValue;
-            IsParameter = createValueArgs.IsParameter;
+            Origin = createValueArgs.Origin;
             Expression = createValueArgs.Expression;
             Tags = createValueArgs.Tags;
         }
@@ -40,9 +41,7 @@
 
         public decimal Primitive { get; private set; }
 
-        public bool IsParameter { get; protected set; }
-
-        public bool IsOutput { get; private set; }
+        public ValueOriginType Origin { get; protected set; }
 
         public TagsCollection Tags { get; init; }
 
@@ -65,14 +64,14 @@
 
         IValue IOrigin.AsResult()
         {
-            IsOutput = true;
+            Origin = ValueOriginType.Result;
             return this;
         }
 
         void IOrigin.MarkAsParameter(string name)
         {
             Name = name;
-            IsParameter = true;
+            Origin = ValueOriginType.Parameter;
         }
 
         internal static Values<T> SumOf(Expression<Func<T[]>> valuesFunc, [CallerMemberName] string fieldName = "")

--- a/src/Fluent.Calculations.Primitives/Collections/Values.cs
+++ b/src/Fluent.Calculations.Primitives/Collections/Values.cs
@@ -1,86 +1,99 @@
-﻿namespace Fluent.Calculations.Primitives.Collections;
-using Fluent.Calculations.Primitives.BaseTypes;
-using Fluent.Calculations.Primitives.Expressions;
-using System.Collections;
-using System.Diagnostics;
-using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
-
-public class Values<T> : IValues<T>, IOrigin where T : class, IValue, new()
+﻿namespace Fluent.Calculations.Primitives.Collections
 {
-    public override string ToString() => $"{Name}";
+    using Fluent.Calculations.Primitives.BaseTypes;
+    using Fluent.Calculations.Primitives.Expressions;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Linq.Expressions;
+    using System.Runtime.CompilerServices;
 
-    internal Values() : this(MakeValueArgs.Compose(StringConstants.Empty, new ExpressionNode(StringConstants.ZeroDigit, ExpressionNodeType.Collection), 0.00m)) { }
-
-    private static readonly Values<T> Empty = new();
-
-    public void Add(T value, [CallerMemberName] string fieldName = "")
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(ValuesDebugView))]
+    public class Values<T> : IValues<T>, IOrigin where T : class, IValue, new()
     {
-        Expression.Arguments.Add(value);
-        Expression.UpdateBody(ComposeExpressionBody(Expression.Arguments.Count));
-        Primitive += value.Primitive;
-        Name = fieldName;
+        public override string ToString() => $"{Name}";
+
+        internal Values() : this(MakeValueArgs.Compose(StringConstants.Empty, new ExpressionNode(StringConstants.ZeroDigit, ExpressionNodeType.Collection), 0.00m)) { }
+
+        private static readonly Values<T> Empty = new();
+
+        public void Add(T value, [CallerMemberName] string fieldName = "")
+        {
+            Expression.Arguments.Add(value);
+            Expression.UpdateBody(ComposeExpressionBody(Expression.Arguments.Count));
+            Primitive += value.Primitive;
+            Name = fieldName;
+        }
+
+        protected Values(MakeValueArgs createValueArgs)
+        {
+            Name = createValueArgs.Name;
+            Primitive = createValueArgs.PrimitiveValue;
+            IsParameter = createValueArgs.IsParameter;
+            Expression = createValueArgs.Expression;
+            Tags = createValueArgs.Tags;
+        }
+
+        public string Name { get; private set; }
+
+        public ExpressionNode Expression { get; init; }
+
+        public decimal Primitive { get; private set; }
+
+        public bool IsParameter { get; protected set; }
+
+        public bool IsOutput { get; private set; }
+
+        public TagsCollection Tags { get; init; }
+
+        public IValue MakeOfThisType(MakeValueArgs args) => new Values<T>(args);
+
+        public IValue MakeOfThisElementType(MakeValueArgs args) => new T().MakeOfThisType(args);
+
+        public IValue GetDefault() => Empty;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        bool IOrigin.IsSet => !Name.IsNaNOrNull();
+
+        public int Count => Expression.Arguments.Count;
+
+        public virtual string ValueToString() => $"{Primitive:0.00}";
+
+        IEnumerator IEnumerable.GetEnumerator() => Expression.Arguments.GetEnumerator();
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => Expression.Arguments.Cast<T>().GetEnumerator();
+
+        IValue IOrigin.AsResult()
+        {
+            IsOutput = true;
+            return this;
+        }
+
+        void IOrigin.MarkAsParameter(string name)
+        {
+            Name = name;
+            IsParameter = true;
+        }
+
+        internal static Values<T> SumOf(Expression<Func<T[]>> valuesFunc, [CallerMemberName] string fieldName = "")
+        {
+            List<T> collectionElements = valuesFunc.Compile().Invoke().ToList();
+            decimal primitiveValue = collectionElements.Sum(value => value.Primitive);
+            var expressionNode = new ExpressionNode(ComposeExpressionBody(collectionElements.Count), ExpressionNodeType.Collection).WithArguments(collectionElements);
+            Values<T> numbers = new(MakeValueArgs.Compose(fieldName, expressionNode, primitiveValue));
+            return numbers;
+        }
+
+        private static string ComposeExpressionBody(int elementCount) => $"{typeof(T).Name}[{elementCount}]";
     }
 
-    protected Values(MakeValueArgs createValueArgs)
+    public class ValuesDebugView
     {
-        Name = createValueArgs.Name;
-        Primitive = createValueArgs.PrimitiveValue;
-        IsParameter = createValueArgs.IsParameter;
-        Expression = createValueArgs.Expression;
-        Tags = createValueArgs.Tags;
+        private readonly IValue collectionValue;
+
+        public ValuesDebugView(IValue collectionValue) => this.collectionValue = collectionValue;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public IValue[] Items => collectionValue.Expression.Arguments.ToArray();
     }
-
-    public string Name { get; private set; }
-
-    public ExpressionNode Expression { get; init; }
-
-    public decimal Primitive { get; private set; }
-
-    public bool IsParameter { get; protected set; }
-
-    public bool IsOutput { get; private set; }
-
-    public TagsCollection Tags { get; init; }
-
-    public IValue MakeOfThisType(MakeValueArgs args) => new Values<T>(args);
-
-    public IValue MakeOfThisElementType(MakeValueArgs args) => new T().MakeOfThisType(args);
-
-    public IValue GetDefault() => Empty;
-
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    bool IOrigin.IsSet => !Name.IsNaNOrNull();
-
-    public int Count => Expression.Arguments.Count;
-
-    public virtual string ValueToString() => $"{Primitive:0.00}";
-
-    IEnumerator IEnumerable.GetEnumerator() => Expression.Arguments.GetEnumerator();
-
-    IEnumerator<T> IEnumerable<T>.GetEnumerator() => Expression.Arguments.Cast<T>().GetEnumerator();
-
-    IValue IOrigin.AsResult()
-    {
-        IsOutput = true;
-        return this;
-    }
-
-    void IOrigin.MarkAsParameter(string name)
-    {
-        Name = name;
-        IsParameter = true;
-    }
-
-    internal static Values<T> SumOf(Expression<Func<T[]>> valuesFunc, [CallerMemberName] string fieldName = "")
-    {
-        List<T> collectionElements = valuesFunc.Compile().Invoke().ToList();
-        decimal primitiveValue = collectionElements.Sum(value => value.Primitive);
-        var expressionNode = new ExpressionNode(ComposeExpressionBody(collectionElements.Count), ExpressionNodeType.Collection).WithArguments(collectionElements);
-        Values<T> numbers = new(MakeValueArgs.Compose(fieldName, expressionNode, primitiveValue));
-        return numbers;
-    }
-
-    private static string ComposeExpressionBody(int elementCount) => $"{typeof(T).Name}[{elementCount}]";
 }
-

--- a/src/Fluent.Calculations.Primitives/Collections/Values.cs
+++ b/src/Fluent.Calculations.Primitives/Collections/Values.cs
@@ -2,6 +2,7 @@
 using Fluent.Calculations.Primitives.BaseTypes;
 using Fluent.Calculations.Primitives.Expressions;
 using System.Collections;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
@@ -11,13 +12,14 @@ public class Values<T> : IValues<T>, IOrigin where T : class, IValue, new()
 
     internal Values() : this(MakeValueArgs.Compose(StringConstants.Empty, new ExpressionNode(StringConstants.ZeroDigit, ExpressionNodeType.Collection), 0.00m)) { }
 
-    private static Values<T> Empty = new Values<T>();
+    private static readonly Values<T> Empty = new();
 
     public void Add(T value, [CallerMemberName] string fieldName = "")
     {
         Expression.Arguments.Add(value);
         Expression.UpdateBody(ComposeExpressionBody(Expression.Arguments.Count));
         Primitive += value.Primitive;
+        Name = fieldName;
     }
 
     protected Values(MakeValueArgs createValueArgs)
@@ -47,6 +49,7 @@ public class Values<T> : IValues<T>, IOrigin where T : class, IValue, new()
 
     public IValue GetDefault() => Empty;
 
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     bool IOrigin.IsSet => !Name.IsNaNOrNull();
 
     public int Count => Expression.Arguments.Count;
@@ -74,7 +77,7 @@ public class Values<T> : IValues<T>, IOrigin where T : class, IValue, new()
         List<T> collectionElements = valuesFunc.Compile().Invoke().ToList();
         decimal primitiveValue = collectionElements.Sum(value => value.Primitive);
         var expressionNode = new ExpressionNode(ComposeExpressionBody(collectionElements.Count), ExpressionNodeType.Collection).WithArguments(collectionElements);
-        Values<T> numbers = new Values<T>(MakeValueArgs.Compose(fieldName, expressionNode, primitiveValue));
+        Values<T> numbers = new(MakeValueArgs.Compose(fieldName, expressionNode, primitiveValue));
         return numbers;
     }
 

--- a/src/Fluent.Calculations.Primitives/Collections/Values.cs
+++ b/src/Fluent.Calculations.Primitives/Collections/Values.cs
@@ -45,7 +45,7 @@ public class Values<T> : IValues<T>, IOrigin where T : class, IValue, new()
 
     public IValue MakeOfThisElementType(MakeValueArgs args) => new T().MakeOfThisType(args);
 
-    public IValue Default => Empty;
+    public IValue GetDefault() => Empty;
 
     bool IOrigin.IsSet => !Name.IsNaNOrNull();
 

--- a/src/Fluent.Calculations.Primitives/Docs/IntelliSense.xml
+++ b/src/Fluent.Calculations.Primitives/Docs/IntelliSense.xml
@@ -66,12 +66,12 @@
 			<returns>Calculation result</returns>
 		</method-ToResult>
 		<method-Evaluate>
-			<summary>TBD</summary>
-			<typeparam name="TValue">TBD</typeparam>
-			<param name="lambdaExpression">TBD</param>
-			<param name="name">A</param>
-			<param name="lambdaExpressionBody">TBD</param>
-			<returns>Labda expression result</returns>
+			<summary>Evaluates an expression and captures arguments.</summary>
+			<typeparam name="TValue">Result value type</typeparam>
+			<param name="lambdaExpression">Math or logic expression</param>
+			<param name="name">Result name (captured by the compiler by default)</param>
+			<param name="lambdaExpressionBody">Expression body (captured by the compiler by default)</param>
+			<returns>Lambda expression result containing arguments and expression body.</returns>
 		</method-Evaluate>
 	</members>
 	<members name="Value">

--- a/src/Fluent.Calculations.Primitives/Docs/IntelliSense.xml
+++ b/src/Fluent.Calculations.Primitives/Docs/IntelliSense.xml
@@ -67,7 +67,7 @@
 		</method-ToResult>
 		<method-Evaluate>
 			<summary>TBD</summary>
-			<typeparam name="ValueType">TBD</typeparam>
+			<typeparam name="TValue">TBD</typeparam>
 			<param name="lambdaExpression">TBD</param>
 			<param name="name">A</param>
 			<param name="lambdaExpressionBody">TBD</param>

--- a/src/Fluent.Calculations.Primitives/EvaluationContext.cs
+++ b/src/Fluent.Calculations.Primitives/EvaluationContext.cs
@@ -83,7 +83,7 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
 
         expressionNode = new ExpressionNode(expressionBody, ExpressionNodeType.Lambda).WithArguments(expressionArguments);
 
-        return (TValue)result.MakeOfThisType(MakeValueArgs.Compose(name, expressionNode, result.Primitive));
+        return (TValue)result.MakeOfThisType(MakeValueArgs.Compose(name, expressionNode, result.Primitive, ValueOriginType.Evaluation));
     }
 
     private IValue[] SelectCachedEvaluationsValues(CapturedEvaluationMember[] evaluations)

--- a/src/Fluent.Calculations.Primitives/EvaluationContext.cs
+++ b/src/Fluent.Calculations.Primitives/EvaluationContext.cs
@@ -43,7 +43,7 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
     }
 
     /// <include file="Docs/IntelliSense.xml" path='docs/members[@name="EvaluationContext"]/method-Return/*' />
-    public virtual T Return() { return (T)new T().Default; }
+    public virtual T Return() { return (T)new T().GetDefault(); }
 
     /// <include file="Docs/IntelliSense.xml" path='docs/members[@name="EvaluationContext"]/method-Evaluate/*' />
     public TValue Evaluate<TValue>(
@@ -97,9 +97,9 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
     {
         foreach (CapturedParameterMember parameter in parameters)
         {
-            IOrigin paramterOrigin = ((IOrigin)parameter.Value);
-            if (options.AlwaysReadNamesFromExpressions || !paramterOrigin.IsSet)
-                paramterOrigin.MarkAsParameter(parameter.MemberName);
+            IOrigin parameterOrigin = ((IOrigin)parameter.Value);
+            if (options.AlwaysReadNamesFromExpressions || !parameterOrigin.IsSet)
+                parameterOrigin.MarkAsParameter(parameter.MemberName);
         }
     }
 }

--- a/src/Fluent.Calculations.Primitives/Expressions/ExpressionNode.cs
+++ b/src/Fluent.Calculations.Primitives/Expressions/ExpressionNode.cs
@@ -1,6 +1,8 @@
 ﻿namespace Fluent.Calculations.Primitives.Expressions;
 using Fluent.Calculations.Primitives.BaseTypes;
+using System.Diagnostics;
 
+[DebuggerDisplay("Body = {Body}")]
 public class ExpressionNode
 {
     public override string ToString() => $"{Body}";

--- a/src/Fluent.Calculations.Primitives/Fluent.Calculations.Primitives.csproj
+++ b/src/Fluent.Calculations.Primitives/Fluent.Calculations.Primitives.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Version>1.0.16-alpha</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,4 +51,7 @@
     </PackageReference>
   </ItemGroup>
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Cleaner look in Debug View and other bits for better comprehension
- Some other minor style check recommendations fixes

![image](https://github.com/jitt-team/fluent-calculations-primitives/assets/19811309/92057172-39b9-4b86-ad12-d9ca4555a81d)

![image](https://github.com/jitt-team/fluent-calculations-primitives/assets/19811309/f5c410f8-ce02-4fde-91ae-08ca1df792a6)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on introducing the `ValueOriginType` enum, updating the `IValue` interface, and making related changes in various classes.

### Detailed summary:
- Added the `ValueOriginType` enum with values `NotSet`, `Parameter`, `Constant`, `Evaluation`, and `Result`.
- Updated the `IValue` interface to replace `IsParameter` and `IsOutput` properties with `Origin` property of type `ValueOriginType`.
- Updated various classes to use the new `ValueOriginType` enum and reflect the changes in their logic and behavior.
- Added a `GetDefault()` method in the `IValue` interface and updated implementations accordingly.
- Added a `DebuggerDisplay` attribute to the `Tag` and `ExpressionNode` classes for better debugging experience.
- Added a `DebuggerTypeProxy` attribute to the `ArgumentsCollection` class for better debugging visualization.
- Updated the `MakeValueArgs` class to include the `Origin` property of type `ValueOriginType`.
- Updated the `EvaluationContext` class to use the `ValueOriginType.Evaluation` when creating new `MakeValueArgs` for evaluation results.
- Updated the `Number` class to use `ValueOriginType.Constant` as the origin for the `Zero` property.
- Updated the `Condition` class to include a `DebuggerDisplay` attribute for better debugging experience.
- Updated the `DotNetGraphBuilderDefault` class to use static helper methods for shape and color determination, and to improve HTML generation for different value types.

> The following files were skipped due to too many changes: `src/Fluent.Calculations.DotNetGraph/DotNetGraphBuilderDefault.cs`, `src/Fluent.Calculations.Primitives/BaseTypes/Value.cs`, `src/Fluent.Calculations.Primitives/Collections/Values.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->