### PR TITLE
81 Setup Docusaurus GitHub pages build publish workflow

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -50,4 +50,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build
+          publish_dir: ./docusaurus/site/build

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - 81-setup-docusaurus-github-pages-buildpublish-workflow
     paths:
       - '.github/workflows/docusaurus.yml'
       - 'docusaurus/site/**'

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -1,6 +1,6 @@
 # .github/workflows/docusaurus.yml
 
-name: GitHub Pages
+name: GitHub Pages (Docusaurus)
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Get yarn cache
         id: yarn-cache

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -1,0 +1,53 @@
+# .github/workflows/docusaurus.yml
+
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - 81-setup-docusaurus-github-pages-buildpublish-workflow
+    paths:
+      - '.github/workflows/docusaurus.yml'
+      - 'docusaurus/site/**'
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    defaults:
+      run:
+        working-directory: docusaurus/site
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "YARN_CACHE_DIR=$(yarn cache dir)" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache.outputs.YARN_CACHE_DIR }}
+          key: ${{ runner.os }}-website-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-website-
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a GitHub Pages workflow for Docusaurus. 

### Detailed summary
- Added a GitHub Pages workflow for Docusaurus.
- The workflow is triggered on push to the main branch and pull requests.
- The workflow runs on ubuntu-22.04.
- The workflow has write permissions for contents.
- The workflow uses concurrency grouping.
- The working directory is set to "docusaurus/site".
- The workflow checks out the code.
- The Node version is set to 18.
- The yarn cache is retrieved.
- Dependencies are cached.
- Yarn is installed and the lockfile is frozen.
- The project is built using yarn.
- The built files are deployed using peaceiris/actions-gh-pages.
- The deployment is only performed for the main branch.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->