### PR TITLE
Clear value cache before calculation

### DIFF
--- a/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
+++ b/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
@@ -11,28 +11,41 @@ namespace Fluent.Calculations.Primitives.Tests.Benchmarks
 
         public CalculationBenchmarks()
         {
-            additionContext = new BasicAdditionWithContext();
+            additionContext = new BasicAdditionWithContext
+            {
+                ConstantOne = Number.Of(2),
+                ConstantTwo = Number.Of(10),
+                ConstantThree = Number.Of(5),
+                ConstantFour = Number.Of(30)
+            };
             additionNative = new BasicAdditionNative();
         }
 
         [Benchmark]
         public void Calculate_UsingContext() => additionContext.ToResult();
 
-        [Benchmark]
+        // [Benchmark]
         public void Calculate_Native() => additionNative.Return();
     }
 
     public class BasicAdditionWithContext : EvaluationContext<Number>
     {
         public BasicAdditionWithContext() : base(new EvaluationOptions { AlwaysReadNamesFromExpressions = false }) { }
+        public Number
+            ConstantOne = Number.Zero,
+            ConstantTwo = Number.Zero,
+            ConstantThree = Number.Zero,
+            ConstantFour = Number.Zero;
 
-        private Number
-            ValueOne = Number.Of(10),
-            ValueTwo = Number.Of(20);
-
-        private Number Result => Evaluate(() => ValueOne + ValueTwo);
-
-        public override Number Return() => Result;
+        public Condition ConstantOneGreaterThanTwo => Evaluate(() => ConstantTwo > ConstantThree);
+        public Number ConstantOneTimesTwo => Evaluate(() => ConstantOne * ConstantTwo);
+        public Number WhenTrueThenValue => Evaluate(() => ConstantOneGreaterThanTwo ? ConstantOneTimesTwo : Number.Zero);
+        public Number ConstantFourPlusWhenTrue => Evaluate(() => ConstantFour + WhenTrueThenValue);
+        public Number ConstantFourPlusWhenTrue2 => Evaluate(() => ConstantFourPlusWhenTrue + WhenTrueThenValue);
+        public Number ConstantFourPlusWhenTrue3 => Evaluate(() => ConstantFour + ConstantFourPlusWhenTrue2);
+        public Number ConstantFourPlusWhenTrue4 => Evaluate(() => ConstantFourPlusWhenTrue3 + WhenTrueThenValue);
+        public Number ConstantFourPlusWhenTrue5 => Evaluate(() => ConstantFour + ConstantFourPlusWhenTrue4);
+        public override Number Return() => ConstantFourPlusWhenTrue5;
     }
 
     public class BasicAdditionNative

--- a/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
+++ b/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
@@ -24,7 +24,7 @@ namespace Fluent.Calculations.Primitives.Tests.Benchmarks
         [Benchmark]
         public void Calculate_UsingContext() => additionContext.ToResult();
 
-        // [Benchmark]
+        [Benchmark]
         public void Calculate_Native() => additionNative.Return();
     }
 

--- a/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
+++ b/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
@@ -40,9 +40,9 @@ namespace Fluent.Calculations.Primitives.Tests.Benchmarks
         public Condition ConstantOneGreaterThanTwo => Evaluate(() => ConstantTwo > ConstantThree);
         public Number ConstantOneTimesTwo => Evaluate(() => ConstantOne * ConstantTwo);
         public Number WhenTrueThenValue => Evaluate(() => ConstantOneGreaterThanTwo ? ConstantOneTimesTwo : Number.Zero);
-        public Number ConstantFourPlusWhenTrue => Evaluate(() => ConstantFour + WhenTrueThenValue);
-        public Number ConstantFourPlusWhenTrue2 => Evaluate(() => ConstantFourPlusWhenTrue + WhenTrueThenValue);
-        public Number ConstantFourPlusWhenTrue3 => Evaluate(() => ConstantFour + ConstantFourPlusWhenTrue2);
+        public Number ConstantFourPlusWhenTrue => Evaluate(() => ConstantFour + WhenTrueThenValue * ConstantOne);
+        public Number ConstantFourPlusWhenTrue2 => Evaluate(() => ConstantFourPlusWhenTrue + WhenTrueThenValue / ConstantThree);
+        public Number ConstantFourPlusWhenTrue3 => Evaluate(() => ConstantFour + ConstantFourPlusWhenTrue2 * ConstantTwo / ConstantFourPlusWhenTrue);
         public Number ConstantFourPlusWhenTrue4 => Evaluate(() => ConstantFourPlusWhenTrue3 + WhenTrueThenValue);
         public Number ConstantFourPlusWhenTrue5 => Evaluate(() => ConstantFour + ConstantFourPlusWhenTrue4);
         public override Number Return() => ConstantFourPlusWhenTrue5;

--- a/src/Fluent.Calculations.Primitives/EvaluationContext.cs
+++ b/src/Fluent.Calculations.Primitives/EvaluationContext.cs
@@ -71,8 +71,6 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
     {
         TValue result = lambdaExpression.Compile().Invoke();
 
-        ExpressionNode expressionNode;
-
         CapturedExpressionMembers members = memberCapturer.Capture(lambdaExpression);
         MarkValuesAsParameters(members.Parameters);
 
@@ -81,7 +79,7 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
             evaluationValues = SelectCachedEvaluationsValues(members.Evaluations),
             expressionArguments = parameterValues.Concat(evaluationValues);
 
-        expressionNode = new ExpressionNode(expressionBody, ExpressionNodeType.Lambda).WithArguments(expressionArguments);
+        ExpressionNode expressionNode = new ExpressionNode(expressionBody, ExpressionNodeType.Lambda).WithArguments(expressionArguments);
 
         return (TValue)result.MakeOfThisType(MakeValueArgs.Compose(name, expressionNode, result.Primitive, ValueOriginType.Evaluation));
     }

--- a/src/Fluent.Calculations.Primitives/EvaluationContext.cs
+++ b/src/Fluent.Calculations.Primitives/EvaluationContext.cs
@@ -92,7 +92,6 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
         bool IsCached(CapturedEvaluationMember evaluation) => valuesCache.ContainsName(evaluation.MemberName);
         IValue GetCachedValue(CapturedEvaluationMember evaluation) => valuesCache.GetByName(evaluation.MemberName);
     }
-
     private void MarkValuesAsParameters(CapturedParameterMember[] parameters)
     {
         foreach (CapturedParameterMember parameter in parameters)

--- a/src/Fluent.Calculations.Primitives/EvaluationContext.cs
+++ b/src/Fluent.Calculations.Primitives/EvaluationContext.cs
@@ -35,6 +35,8 @@ public class EvaluationContext<T> : IEvaluationContext<T> where T : class, IValu
     /// <include file="Docs/IntelliSense.xml" path='docs/members[@name="EvaluationContext"]/method-ToResult/*' />
     public T ToResult()
     {
+        valuesCache.Clear();
+
         T result = calculationFunc != null ?
              calculationFunc.Invoke(this) :
              Return();

--- a/src/Fluent.Calculations.Primitives/Expressions/IValuesCache.cs
+++ b/src/Fluent.Calculations.Primitives/Expressions/IValuesCache.cs
@@ -16,4 +16,6 @@ public interface IValuesCache
     IValue GetByName(string name);
 
     bool TryGetValue(string key, out IValue? cachedValue);
+
+    void Clear();
 }

--- a/src/Fluent.Calculations.Primitives/Expressions/ValuesCache.cs
+++ b/src/Fluent.Calculations.Primitives/Expressions/ValuesCache.cs
@@ -5,7 +5,7 @@ internal class ValuesCache : IValuesCache
 {
     private readonly IDictionary<string, IValue> cache;
 
-    public ValuesCache() : this(new Dictionary<string, IValue>()) { }
+    public ValuesCache() : this(new Dictionary<string, IValue>(100)) { }
 
     public ValuesCache(IDictionary<string, IValue> cache) => this.cache = cache;
 
@@ -22,4 +22,6 @@ internal class ValuesCache : IValuesCache
     public bool ContainsName(string name) => cache.Values.Any(value => value.Name == name);
 
     public IValue GetByName(string name) => cache.Values.Single(value => value.Name == name);
+
+    public void Clear() => cache.Clear();
 }


### PR DESCRIPTION
- Clear cache for repeated runs
- A bit heavier benchmark case

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a `Clear` method to the `ValuesCache` class and making changes to the `EvaluationContext` and `CalculationBenchmarks` classes.

### Detailed summary:
- Added a `Clear` method to the `IValuesCache` interface.
- Implemented the `Clear` method in the `ValuesCache` class.
- Modified the `ValuesCache` constructor to accept an initial capacity for the cache dictionary.
- Added a call to `valuesCache.Clear()` in the `ToResult` method of the `EvaluationContext` class.
- Added new properties and calculations to the `BasicAdditionWithContext` class in the `CalculationBenchmarks` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->