### PR TITLE
Address VS syntax recommendations

### DIFF
--- a/src/Fluent.Calculations.DotNetGraph.Tests/CalculationDotGraphRendererTests.cs
+++ b/src/Fluent.Calculations.DotNetGraph.Tests/CalculationDotGraphRendererTests.cs
@@ -34,7 +34,7 @@ namespace Fluent.Calculations.Primitives.Tests.DotNetGraph
             }
         }
 
-        private Number RunCalculation() => new AdditionCalculation
+        private static Number RunCalculation() => new AdditionCalculation
         {
             ConstantOne = Number.Of(2),
             ConstantTwo = Number.Of(3)

--- a/src/Fluent.Calculations.DotNetGraph.Tests/Fluent.Calculations.DotNetGraph.Tests.csproj
+++ b/src/Fluent.Calculations.DotNetGraph.Tests/Fluent.Calculations.DotNetGraph.Tests.csproj
@@ -12,10 +12,10 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="QuikGraph.Graphviz" Version="2.5.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Fluent.Calculations.DotNetGraph/DotGraphValueBuilder.cs
+++ b/src/Fluent.Calculations.DotNetGraph/DotGraphValueBuilder.cs
@@ -3,7 +3,6 @@ using DotNetGraph.Extensions;
 using Fluent.Calculations.DotNetGraph.Shared;
 using Fluent.Calculations.DotNetGraph.Styles;
 using Fluent.Calculations.Primitives.BaseTypes;
-using Fluent.Calculations.Primitives.Collections;
 namespace Fluent.Calculations.DotNetGraph;
 
 public class DotGraphValueBuilder
@@ -17,7 +16,7 @@ public class DotGraphValueBuilder
     public DotGraph Build(IValue value)
     {
         DotGraph mainGraph = CreateDirectedGraph("FluentCalculations");
-        ClusterProvider parameterClustersProvider = new ClusterProvider(builder, mainGraph);
+        ClusterProvider parameterClustersProvider = new(builder, mainGraph);
         DotNodeBlock finalResultBlock = AddToGraph(value, mainGraph, parameterClustersProvider);
         AddFinalResultNode(finalResultBlock.FirstNode, mainGraph, value);
 
@@ -38,7 +37,7 @@ public class DotGraphValueBuilder
     {
         DotNodeBlock parentNode = builder.CreateBlock(value);
 
-        DotBaseGraph graph = IsParameter() ? 
+        DotBaseGraph graph = IsParameter() ?
             parameterClustersProvider.GetOrCreateParametersSubgraph(value.Scope) :
             parameterClustersProvider.GetOrCreateScopeSubgraph(value.Scope);
 
@@ -59,8 +58,8 @@ public class DotGraphValueBuilder
     private sealed class ClusterProvider
     {
         private readonly Dictionary<string, DotSubgraph>
-            scopeParameterContainers = new Dictionary<string, DotSubgraph>(),
-            scopeContainers = new Dictionary<string, DotSubgraph>();
+            scopeParameterContainers = [],
+            scopeContainers = [];
 
         private readonly IGraphStyle builder;
         private readonly DotGraph mainGraph;
@@ -75,9 +74,7 @@ public class DotGraphValueBuilder
 
         public DotSubgraph GetOrCreateScopeSubgraph(string scope)
         {
-            DotSubgraph subgraph;
-
-            if (scopeContainers.TryGetValue(scope, out subgraph))
+            if (scopeContainers.TryGetValue(scope, out DotSubgraph? subgraph))
                 return subgraph;
 
             subgraph = builder.CreateScopeCluster(scope, GetCurrentScopeIndex() + 1);
@@ -85,14 +82,11 @@ public class DotGraphValueBuilder
             mainGraph.Add(subgraph);
 
             return subgraph;
-
         }
 
         public DotSubgraph GetOrCreateParametersSubgraph(string scope)
         {
-            DotSubgraph? scopeParametersSubgraph;
-
-            if (scopeParameterContainers.TryGetValue(scope, out scopeParametersSubgraph))
+            if (scopeParameterContainers.TryGetValue(scope, out DotSubgraph? scopeParametersSubgraph))
                 return scopeParametersSubgraph;
 
             scopeParametersSubgraph = builder.CreateParametersCluster(scope, GetCurrentScopeIndex() + 1);

--- a/src/Fluent.Calculations.DotNetGraph/Styles/GraphStyleMonochrome.cs
+++ b/src/Fluent.Calculations.DotNetGraph/Styles/GraphStyleMonochrome.cs
@@ -60,13 +60,13 @@ internal class GraphStyleMonochrome : IGraphStyle
         return node;
     }
 
-    private DotNodeBlock CreateValueBlock(IValue value)
+    private static DotNodeBlock CreateValueBlock(IValue value)
     {
         DotNode node = CreateBaseNodeStyle(value.Name).WithLabel(ComposeHtmlLabel(value), isHtml: true);
         return new DotNodeBlock(node, true);
     }
 
-    private DotNode CreateBaseNodeStyle(string name)
+    private static DotNode CreateBaseNodeStyle(string name)
     {
         DotNode node = new DotNode()
                 .WithIdentifier(Html($"{name}_value"))
@@ -80,7 +80,7 @@ internal class GraphStyleMonochrome : IGraphStyle
         return node;
     }
 
-    private string ComposeHtmlLabel(IValue value) => $@"
+    private static string ComposeHtmlLabel(IValue value) => $@"
             <table border=""0"" cellborder=""0"" cellpadding=""3"" bgcolor=""white"">
                 <tr>
                     <td bgcolor=""black"" align=""center"" colspan=""2""><font color=""white"">{Humanize(value.Name)}</font></td>
@@ -88,7 +88,7 @@ internal class GraphStyleMonochrome : IGraphStyle
                  {ValueRow(value)}
             </table>";
 
-    private string ValueRow(IValue value) => IsParameter(value) ?
+    private static string ValueRow(IValue value) => IsParameter(value) ?
             $@"<tr>
                 <td align=""center"" port=""r1"">{Html(value.Expression.Body)}</td>
             </tr>" :
@@ -98,11 +98,10 @@ internal class GraphStyleMonochrome : IGraphStyle
                 <td bgcolor=""grey"" align=""center"">{value.PrimitiveString}</td>
             </tr>";
 
-    private bool IsParameter(IValue value) => value.Origin == ValueOriginType.Constant || value.Origin == ValueOriginType.Parameter;
+    private static bool IsParameter(IValue value) => value.Origin == ValueOriginType.Constant || value.Origin == ValueOriginType.Parameter;
 
     private static string Html(string value) => HttpUtility.HtmlEncode(value).Replace(Environment.NewLine, @"<br align=""left""/>");
 
-
-    private string Humanize(string cammelCaseText) => Regex.Replace(cammelCaseText, @"(\B[A-Z])", " $1", RegexOptions.Compiled, TimeSpan.FromSeconds(1)).Trim();
+    private static string Humanize(string cammelCaseText) => Regex.Replace(cammelCaseText, @"(\B[A-Z])", " $1", RegexOptions.Compiled, TimeSpan.FromSeconds(1)).Trim();
 
 }

--- a/src/Fluent.Calculations.Graphviz/Program.cs
+++ b/src/Fluent.Calculations.Graphviz/Program.cs
@@ -40,7 +40,7 @@ namespace Fluent.Calculations.Graphviz
     {
         public DemoCalculation() : base(new EvaluationOptions { AlwaysReadNamesFromExpressions = true, Scope = "DemoCalculation" }) { }
 
-        private readonly RelatedCalculation ChildCalculation = new RelatedCalculation();
+        private readonly RelatedCalculation ChildCalculation = new();
 
         private readonly Number
             ValueOne = Number.Of(30),

--- a/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
+++ b/src/Fluent.Calculations.Primitives.Benchmarks/CalculationBenchmarks.cs
@@ -50,7 +50,7 @@ namespace Fluent.Calculations.Primitives.Tests.Benchmarks
 
     public class BasicAdditionNative
     {
-        private decimal
+        private readonly decimal
             ValueOne = 10,
             ValueTwo = 20;
 

--- a/src/Fluent.Calculations.Primitives.Benchmarks/Fluent.Calculations.Primitives.Benchmarks.csproj
+++ b/src/Fluent.Calculations.Primitives.Benchmarks/Fluent.Calculations.Primitives.Benchmarks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fluent.Calculations.Primitives.Benchmarks/Program.cs
+++ b/src/Fluent.Calculations.Primitives.Benchmarks/Program.cs
@@ -1,6 +1,5 @@
-﻿using BenchmarkDotNet.Reports;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using Fluent.Calculations.Primitives.Tests.Benchmarks;
 
-Summary summary = BenchmarkRunner.Run<CalculationBenchmarks>();
+BenchmarkRunner.Run<CalculationBenchmarks>();
 Console.ReadLine();

--- a/src/Fluent.Calculations.Primitives.Tests/BaseTypes/ConditionTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/BaseTypes/ConditionTests.cs
@@ -4,48 +4,48 @@ namespace Fluent.Calculations.Primitives.Tests.BaseTypes;
 public class ConditionTests
 {
     [Fact(DisplayName = "Condition instance of True should equal Boolean True")]
-    public void should_be_true() => Condition.True().IsTrue.Should().BeTrue();
+    public void Should_be_true() => Condition.True().IsTrue.Should().BeTrue();
 
     [Fact]
-    public void should_be_false() => Condition.False().IsTrue.Should().BeFalse();
+    public void Should_be_false() => Condition.False().IsTrue.Should().BeFalse();
 
     [Fact]
-    public void greater_with_left_greater_should_be_true()
+    public void Greater_with_left_greater_should_be_true()
     {
         Condition result = Number.Of(10) > Number.Of(1);
         result.IsTrue.Should().BeTrue();
     }
 
     [Fact]
-    public void lesser_with_left_greater_should_be_false()
+    public void Lesser_with_left_greater_should_be_false()
     {
         Condition result = Number.Of(10) < Number.Of(1);
         result.IsTrue.Should().BeFalse();
     }
 
     [Fact]
-    public void equalling_non_equal_should_be_false()
+    public void Equalling_non_equal_should_be_false()
     {
         Condition result = Number.Of(10) == Number.Of(1);
         result.IsTrue.Should().BeFalse();
     }
 
     [Fact]
-    public void equalling_equal_should_be_true()
+    public void Equalling_equal_should_be_true()
     {
         Condition result = Number.Of(10) == Number.Of(10);
         result.IsTrue.Should().BeTrue();
     }
 
     [Fact]
-    public void nonEqualling_not_equal_should_be_true()
+    public void NonEqualling_not_equal_should_be_true()
     {
         Condition result = Number.Of(10) != Number.Of(1);
         result.IsTrue.Should().BeTrue();
     }
 
     [Fact]
-    public void nonEqualling_equal_should_be_false()
+    public void NonEqualling_equal_should_be_false()
     {
         Condition result = Number.Of(10) != Number.Of(10);
         result.IsTrue.Should().BeFalse();

--- a/src/Fluent.Calculations.Primitives.Tests/BaseTypes/ValueTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/BaseTypes/ValueTests.cs
@@ -9,7 +9,7 @@ public class ValueTests
     public void ValueConstructor_WithArgs_CreatesExpectedInstance()
     {
         string expectedValueName = "TEST-VALUE-NAME";
-        ExpressionNode expectedExpressionNode = new ExpressionNode("TEST-BODY", "TEST-TYPE");
+        ExpressionNode expectedExpressionNode = new("TEST-BODY", "TEST-TYPE");
         decimal expectedPrimitiveValue = 10m;
 
         FakeInheritedValue fakeValue = new(MakeValueArgs.Compose(expectedValueName, expectedExpressionNode, expectedPrimitiveValue));

--- a/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/ComplexValueTypesTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/ComplexValueTypesTests.cs
@@ -3,10 +3,10 @@ namespace Fluent.Calculations.Primitives.Tests.ComplexValueType;
 
 public class ComplexValueTypesTests
 {
-    private Money Return()
+    private static Money Return()
     {
         EvaluationOptions options = new() { AlwaysReadNamesFromExpressions = true };
-        EvaluationScope<Money> Calculation = new EvaluationScope<Money>();
+        EvaluationScope<Money> Calculation = new();
 
         Money
             MoneyOne = Number.Of(10).AsMoney().EUR,

--- a/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Currency/Currency.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Currency/Currency.cs
@@ -4,7 +4,7 @@ public class Currency : IComparable, IEquatable<Currency>, IComparable<Currency>
 {
     private const string NoneCorrencyCode = "None";
 
-    public static Currency None => new Currency(NoneCorrencyCode);
+    public static Currency None => new(NoneCorrencyCode);
 
     public string Code { get; }
 

--- a/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/Money.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/Money.cs
@@ -17,11 +17,11 @@ public class Money : Number
 
     public Money(MakeValueArgs makeValueArgs, Currency currency) : base(makeValueArgs) => Currency = currency;
 
-    public static Money operator +(Money left, Money right) => new Money(left.Add(right), left.Currency);
+    public static Money operator +(Money left, Money right) => new(left.Add(right), left.Currency);
 
-    public static Money operator *(Money left, Number right) => new Money(left.Multiply(right), left.Currency);
+    public static Money operator *(Money left, Number right) => new(left.Multiply(right), left.Currency);
 
-    public static Money operator *(Number left, Money right) => new Money(right.Multiply(left), right.Currency);
+    public static Money operator *(Number left, Money right) => new(right.Multiply(left), right.Currency);
 
     public override IValueProvider MakeOfThisType(MakeValueArgs args) => new Money(args, Currency);
 

--- a/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/MoneyBuilder.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/MoneyBuilder.cs
@@ -3,14 +3,12 @@ using Fluent.Calculations.Primitives.BaseTypes;
 
 public class MoneyBuilder
 {
-    private Number value;
-    private string expressionName;
+    private readonly Number value;
 
-    public MoneyBuilder(Number value, string expressionName)
+    public MoneyBuilder(Number value)
     {
         this.value = value;
-        this.expressionName = expressionName;
     }
 
-    public Money EUR => new Money(value, new Currency("EUR"));
+    public Money EUR => new(value, new Currency("EUR"));
 }

--- a/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/ToMoney.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/ComplexValueType/Money/ToMoney.cs
@@ -1,8 +1,7 @@
 ﻿namespace Fluent.Calculations.Primitives.Tests.ComplexValueType;
 using Fluent.Calculations.Primitives.BaseTypes;
-using System.Runtime.CompilerServices;
 
 public static class ToMoney
 {
-    public static MoneyBuilder AsMoney(this Number value, [CallerMemberName] string expressionName = "") => new MoneyBuilder(value, expressionName);
+    public static MoneyBuilder AsMoney(this Number value) => new(value);
 }

--- a/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ValueCollectionWithAggregateMethodTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/EndToEnd/ValueCollectionWithAggregateMethodTests.cs
@@ -50,14 +50,14 @@ namespace Fluent.Calculations.Primitives.Tests.EndToEnd
         {
             public CollectionsEvaluations() : base(new EvaluationOptions { AlwaysReadNamesFromExpressions = true }) { }
 
-            Number SingleNumber = Number.Of(2);
+            readonly Number SingleNumber = Number.Of(2);
 
-            Values<Number> MultipleNumbers = new()
-            {
+            readonly Values<Number> MultipleNumbers =
+            [
                 Number.Of(2, "COLLECTION-NUMBER-1"),
                 Number.Of(4, "COLLECTION-NUMBER-2"),
                 Number.Of(6, "COLLECTION-NUMBER-3")
-            };
+            ];
 
             public Number AverageFromMultipleNumbers => Evaluate(() => MultipleNumbers.Average());
 

--- a/src/Fluent.Calculations.Primitives.Tests/Expressions/MemberExpressionValueCapturerTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/Expressions/MemberExpressionValueCapturerTests.cs
@@ -24,7 +24,7 @@ public class MemberExpressionValueCapturerTests
     {
         var testMemberClass = new TestMembersClass();
 
-        Mock<IValuesCache> valueCacheMock = new Mock<IValuesCache>(MockBehavior.Strict);
+        Mock<IValuesCache> valueCacheMock = new(MockBehavior.Strict);
         valueCacheMock.Setup(c => c.ContainsKey(It.IsAny<string>())).Returns(false);
         valueCacheMock.Setup(c => c.Add(It.IsAny<string>(), It.IsAny<IValueProvider>())).Verifiable();
 
@@ -43,7 +43,7 @@ public class MemberExpressionValueCapturerTests
         var testMemberClass = new TestMembersClass();
         string cachedParameterName = "CACHED-TEST-PARAMETER";
 
-        Mock<IValuesCache> valueCacheMock = new Mock<IValuesCache>(MockBehavior.Strict);
+        Mock<IValuesCache> valueCacheMock = new(MockBehavior.Strict);
         valueCacheMock.Setup(c => c.ContainsKey(It.IsAny<string>())).Returns(true);
         valueCacheMock.Setup(c => c.GetByKey(It.IsAny<string>())).Returns(Number.Of(3.00m, cachedParameterName));
 
@@ -59,7 +59,7 @@ public class MemberExpressionValueCapturerTests
     public void CaptureEvaluationMember_IsReturned()
     {
         var testMemberClass = new TestMembersClass();
-        CapturedExpressionMembers result = BuildCapturer().Capture(() => testMemberClass.TestEvaluation);
+        CapturedExpressionMembers result = BuildCapturer().Capture(() => TestMembersClass.TestEvaluation);
 
         result.Evaluations.Should().HaveCount(1);
         result.Evaluations.Single().MemberName.Should().Be(TestMembersClass.TestEvaluationName);
@@ -75,7 +75,7 @@ public class MemberExpressionValueCapturerTests
 
         public Number TestParameter = Number.Of(1.00m, TestParameterName);
 
-        public Number TestEvaluation => Number.Of(2.00m, TestEvaluationName);
+        public static Number TestEvaluation => Number.Of(2.00m, TestEvaluationName);
     }
 
     MemberExpressionValueCapturer BuildTestParameterCapturer(TestMembersClass testClass, IValuesCache valueCache)
@@ -97,11 +97,11 @@ public class MemberExpressionValueCapturerTests
 
         reflectionProviderMock.Setup(p => p.IsParameter(It.IsAny<MemberInfo>())).Returns(false);
         reflectionProviderMock.Setup(p => p.IsEvaluation(It.IsAny<MemberInfo>())).Returns(true);
-        reflectionProviderMock.Setup(p => p.GetValue(It.IsAny<Expression>())).Returns(testClass.TestEvaluation);
+        reflectionProviderMock.Setup(p => p.GetValue(It.IsAny<Expression>())).Returns(TestMembersClass.TestEvaluation);
         reflectionProviderMock.Setup(p => p.GetPropertyOrFieldName(It.IsAny<MemberInfo>())).Returns(TestMembersClass.TestEvaluationName);
 
         return new MemberExpressionValueCapturer(expressionMembersCapturerMock.Object, reflectionProviderMock.Object, valueCache);
     }
 
-    MemberExpression GetLambdaBody(Expression expression) => (MemberExpression)((LambdaExpression)expression).Body;
+    private static MemberExpression GetLambdaBody(Expression expression) => (MemberExpression)((LambdaExpression)expression).Body;
 }

--- a/src/Fluent.Calculations.Primitives.Tests/Expressions/MemberExpressionsCapturerTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/Expressions/MemberExpressionsCapturerTests.cs
@@ -12,16 +12,16 @@ public class MemberExpressionsCapturerTests
         MemberExpressionsCapturer capturer = new();
         TestClass testClass = new();
 
-        MemberExpression[] captureResult = capturer.Capture(() => testClass.TestFieldOne + testClass.TestFieldTwo + testClass.TestEvaluationOne + testClass.TestEvaluationTwo);
+        MemberExpression[] captureResult = capturer.Capture(() => TestClass.TestFieldOne + TestClass.TestFieldTwo + TestClass.TestEvaluationOne + TestClass.TestEvaluationTwo);
 
-        string[] expectedMemberNames = new[] {
-            nameof(testClass.TestFieldOne),
-            nameof(testClass.TestFieldTwo),
-            nameof(testClass.TestEvaluationOne),
-            nameof(testClass.TestEvaluationTwo)
-        };
+        string[] expectedMemberNames = [
+            nameof(TestClass.TestFieldOne),
+            nameof(TestClass.TestFieldTwo),
+            nameof(TestClass.TestEvaluationOne),
+            nameof(TestClass.TestEvaluationTwo)
+        ];
 
-        captureResult.Count().Should().Be(4);
+        captureResult.Length.Should().Be(4);
         captureResult.Should().Contain(e => expectedMemberNames.Contains(e.Member.Name));
     }
 
@@ -31,14 +31,14 @@ public class MemberExpressionsCapturerTests
         MemberExpressionsCapturer capturer = new();
         TestClass testClass = new();
 
-        MemberExpression[] captureResult = capturer.Capture(() => testClass.TestFieldOne + testClass.TestFieldOne + testClass.TestEvaluationOne + testClass.TestEvaluationOne);
+        MemberExpression[] captureResult = capturer.Capture(() => TestClass.TestFieldOne + TestClass.TestFieldOne + TestClass.TestEvaluationOne + TestClass.TestEvaluationOne);
 
-        string[] expectedMemberNames = new[] {
-            nameof(testClass.TestFieldOne),
-            nameof(testClass.TestEvaluationOne)
-        };
+        string[] expectedMemberNames = [
+            nameof(TestClass.TestFieldOne),
+            nameof(TestClass.TestEvaluationOne)
+        ];
 
-        captureResult.Count().Should().Be(2);
+        captureResult.Length.Should().Be(2);
         captureResult.Should().Contain(e => expectedMemberNames.Contains(e.Member.Name));
     }
 
@@ -48,14 +48,14 @@ public class MemberExpressionsCapturerTests
         MemberExpressionsCapturer capturer = new();
         TestClass testClass = new();
         decimal unsupportedValueType = 1;
-        MemberExpression[] captureResult = capturer.Capture(() => unsupportedValueType > 2 ? testClass.TestFieldOne : testClass.TestFieldTwo);
+        MemberExpression[] captureResult = capturer.Capture(() => unsupportedValueType > 2 ? TestClass.TestFieldOne : TestClass.TestFieldTwo);
 
-        string[] expectedMemberNames = new[] {
+        string[] expectedMemberNames = [
             nameof(testClass.TestFieldOne),
             nameof(testClass.TestFieldTwo)
-        };
+        ];
 
-        captureResult.Count().Should().Be(2);
+        captureResult.Length.Should().Be(2);
         captureResult.Should().Contain(e => expectedMemberNames.Contains(e.Member.Name));
     }
 
@@ -65,15 +65,15 @@ public class MemberExpressionsCapturerTests
         MemberExpressionsCapturer capturer = new();
         TestClass testClass = new();
 
-        MemberExpression[] captureResult = capturer.Capture(() => testClass.TestCondition ? testClass.TestFieldOne : testClass.TestFieldTwo);
+        MemberExpression[] captureResult = capturer.Capture(() => TestClass.TestCondition ? TestClass.TestFieldOne : TestClass.TestFieldTwo);
 
-        string[] expectedMemberNames = new[] {
+        string[] expectedMemberNames = [
             nameof(testClass.TestFieldOne),
             nameof(testClass.TestFieldTwo),
             nameof(testClass.TestCondition)
-        };
+        ];
 
-        captureResult.Count().Should().Be(3);
+        captureResult.Length.Should().Be(3);
         captureResult.Should().Contain(e => expectedMemberNames.Contains(e.Member.Name));
     }
 
@@ -83,29 +83,29 @@ public class MemberExpressionsCapturerTests
         MemberExpressionsCapturer capturer = new();
         TestClass testClass = new();
 
-        MemberExpression[] captureResult = capturer.Capture(() => CustomFunction(testClass.TestFieldOne, testClass.TestFieldTwo));
+        MemberExpression[] captureResult = capturer.Capture(() => CustomFunction(TestClass.TestFieldOne, TestClass.TestFieldTwo));
 
-        string[] expectedMemberNames = new[] {
+        string[] expectedMemberNames = [
             nameof(testClass.TestFieldOne),
             nameof(testClass.TestFieldTwo)
-        };
+        ];
 
-        captureResult.Count().Should().Be(2);
+        captureResult.Length.Should().Be(2);
         captureResult.Should().Contain(e => expectedMemberNames.Contains(e.Member.Name));
     }
 
-    private Number CustomFunction(Number val1, Number val2) => val1 + val2;
+    private static Number CustomFunction(Number val1, Number val2) => val1 + val2;
 }
 
 public class TestClass
 {
-    public Number TestFieldOne = Number.Of(5.00m);
+    public static Number TestFieldOne => Number.Of(5.00m);
 
-    public Number TestFieldTwo = Number.Of(6.00m);
+    public static Number TestFieldTwo => Number.Of(6.00m);
 
-    public Number TestEvaluationOne => Number.Of(7.00m);
+    public static Number TestEvaluationOne => Number.Of(7.00m);
 
-    public Number TestEvaluationTwo => Number.Of(8.00m);
+    public static Number TestEvaluationTwo => Number.Of(8.00m);
 
-    public Condition TestCondition => Condition.True();
+    public static Condition TestCondition => Condition.True();
 }

--- a/src/Fluent.Calculations.Primitives.Tests/Expressions/ValueArgumentsSelectorTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/Expressions/ValueArgumentsSelectorTests.cs
@@ -19,16 +19,16 @@ public class ValueArgumentsSelectorTests
         arguments[3].Name.Should().Be("SomeEvaluaton");
     }
 
-    private Number GetResult()
+    private static Number GetResult()
     {
         Number
             one = Number.Of(1, nameof(one)),
             two = Number.Of(2, nameof(two)),
             three = Number.Of(3, nameof(three));
 
-        return one + two * three - three / MockEvaluationResult(two);
+        return one + two * three - three / MockEvaluationResult();
     }
 
-    private Number MockEvaluationResult(Number two) => new(MakeValueArgs.Compose("SomeEvaluaton",
+    private static Number MockEvaluationResult() => new(MakeValueArgs.Compose("SomeEvaluaton",
             new ExpressionNode("10", ExpressionNodeType.Lambda), 10, ValueOriginType.Evaluation));
 }

--- a/src/Fluent.Calculations.Primitives.Tests/Expressions/ValuesCacheTests.cs
+++ b/src/Fluent.Calculations.Primitives.Tests/Expressions/ValuesCacheTests.cs
@@ -8,7 +8,7 @@ public class ValuesCacheTests
     [Fact]
     public void ValueIsAddedToCache()
     {
-        Dictionary<string, IValueProvider> cacheStorage = new();
+        Dictionary<string, IValueProvider> cacheStorage = [];
         ValuesCache cache = new(cacheStorage);
         string testValueName = "TEST-VALUE";
         cache.Add(Number.Of(1, testValueName));

--- a/src/Fluent.Calculations.Primitives.Tests/Fluent.Calculations.Primitives.Tests.csproj
+++ b/src/Fluent.Calculations.Primitives.Tests/Fluent.Calculations.Primitives.Tests.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsCollection.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsCollection.cs
@@ -8,15 +8,15 @@ public sealed class ArgumentsCollection : IArguments
 {
     private readonly List<IValue> items;
 
-    private ArgumentsCollection() => items = new List<IValue>();
+    private ArgumentsCollection() => items = [];
 
     internal ArgumentsCollection(IEnumerable<IValue> arguments) => items = new List<IValue>(arguments);
 
-    internal static ArgumentsCollection Empty => new ArgumentsCollection();
+    internal static ArgumentsCollection Empty => new();
 
     public int Count => items.Count;
 
-    internal static ArgumentsCollection CreateFrom(IValue[] arguments) => new ArgumentsCollection(arguments);
+    internal static ArgumentsCollection CreateFrom(IValue[] arguments) => new(arguments);
 
     public IEnumerator<IValue> GetEnumerator() => items.GetEnumerator();
 

--- a/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsDebugView.cs
+++ b/src/Fluent.Calculations.Primitives/BaseTypes/ArgumentsDebugView.cs
@@ -1,14 +1,12 @@
-﻿namespace Fluent.Calculations.Primitives.BaseTypes
+﻿namespace Fluent.Calculations.Primitives.BaseTypes;
+using System.Diagnostics;
+
+public class ArgumentsDebugView
 {
-    using System.Diagnostics;
+    private readonly IArguments arguments;
 
-    public class ArgumentsDebugView
-    {
-        private readonly IArguments arguments;
+    public ArgumentsDebugView(IArguments arguments) => this.arguments = arguments;
 
-        public ArgumentsDebugView(IArguments arguments) => this.arguments = arguments;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public IValue[] Arguments => arguments.ToArray();
-    }
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public IValue[] Arguments => arguments.ToArray();
 }

--- a/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
+++ b/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
@@ -131,11 +131,11 @@ public static class SwitchExpression<T, TReturn>
             List<IValue> expressionArguments = [checkValue];
             decimal resultPrimitive;
 
-            if (switchResult.IsPrimitive)
-                resultPrimitive = switchResult.PrimitiveValue;
+            if (switchResult.IsPrimitive && switchResult == null)
+                resultPrimitive = switchResult?.PrimitiveValue ?? 0;
             else
             {
-                TReturn resultValue = switchResult.Get();
+                TReturn resultValue = switchResult?.Get != null ? switchResult.Get() : new TReturn();
                 resultPrimitive = resultValue.Primitive;
                 expressionArguments.Add(resultValue);
             }
@@ -176,11 +176,11 @@ public static class SwitchExpression<T, TReturn>
 
         public ReturnValue(decimal primitive, string name) : this(name) => PrimitiveValue = primitive;
 
-        public Func<TReturn> Get { get; private set; }
+        public Func<TReturn>? Get { get; private set; }
 
         public decimal PrimitiveValue { get; private set; }
 
-        public string Name { get; private set; }
+        public string Name { get; private set; } = StringConstants.NaN;
 
         public bool IsPrimitive => Get == null;
     }

--- a/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
+++ b/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
@@ -135,7 +135,7 @@ public static class SwitchExpression<T, TReturn>
                 resultPrimitive = switchResult?.PrimitiveValue ?? 0;
             else
             {
-                TReturn resultValue = switchResult?.Get != null ? switchResult.Get() : new TReturn();
+                TReturn resultValue = switchResult.Get();
                 resultPrimitive = resultValue.Primitive;
                 expressionArguments.Add(resultValue);
             }
@@ -176,7 +176,7 @@ public static class SwitchExpression<T, TReturn>
 
         public ReturnValue(decimal primitive, string name) : this(name) => PrimitiveValue = primitive;
 
-        public Func<TReturn>? Get { get; private set; }
+        public Func<TReturn> Get { get; private set; } = () => new TReturn();
 
         public decimal PrimitiveValue { get; private set; }
 

--- a/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
+++ b/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
@@ -131,7 +131,7 @@ public static class SwitchExpression<T, TReturn>
             List<IValue> expressionArguments = [checkValue];
             decimal resultPrimitive;
 
-            if (switchResult.IsPrimitive && switchResult == null)
+            if (switchResult.IsPrimitive)
                 resultPrimitive = switchResult?.PrimitiveValue ?? 0;
             else
             {

--- a/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
+++ b/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
@@ -132,7 +132,7 @@ public static class SwitchExpression<T, TReturn>
             decimal resultPrimitive;
 
             if (switchResult.IsPrimitive)
-                resultPrimitive = switchResult?.PrimitiveValue ?? 0;
+                resultPrimitive = switchResult.PrimitiveValue;
             else
             {
                 TReturn resultValue = switchResult.Get();

--- a/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
+++ b/src/Fluent.Calculations.Primitives/Switch/SwitchExpression.cs
@@ -174,7 +174,11 @@ public static class SwitchExpression<T, TReturn>
 
         public ReturnValue(Func<TReturn> getter, string name) : this(name) => Get = getter;
 
-        public ReturnValue(decimal primitive, string name) : this(name) => PrimitiveValue = primitive;
+        public ReturnValue(decimal primitive, string name) : this(name)
+        {
+            IsPrimitive = true;
+            PrimitiveValue = primitive;
+        }
 
         public Func<TReturn> Get { get; private set; } = () => new TReturn();
 
@@ -182,6 +186,6 @@ public static class SwitchExpression<T, TReturn>
 
         public string Name { get; private set; } = StringConstants.NaN;
 
-        public bool IsPrimitive => Get == null;
+        public bool IsPrimitive { get; private set; }
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving code readability and maintainability by making various changes such as adding `readonly` modifier, using `new()` instead of `new ClassName()`, updating package references, and fixing method names.

### Detailed summary:
- Added `readonly` modifier to `ValueOne` and `ValueTwo` fields in `BasicAdditionNative` class.
- Changed `RunCalculation` method in `CalculationDotGraphRendererTests` to `private static`.
- Updated `BenchmarkDotNet` package reference from version 0.13.10 to 0.13.11 in `Fluent.Calculations.Primitives.Benchmarks.csproj`.
- Replaced `new Currency(NoneCorrencyCode)` with `Currency.None` in `Currency` class.
- Removed unused variable `summary` and updated `BenchmarkRunner.Run<CalculationBenchmarks>()` in `Program.cs`.
- Replaced `Dictionary<string, IValueProvider> cacheStorage = new()` with `Dictionary<string, IValueProvider> cacheStorage = []` in `ValuesCacheTests` class.
- Updated `ChildCalculation` field initialization in `DemoCalculation` class to use `new()` instead of `new RelatedCalculation()`.
- Changed `Return` method in `ComplexValueTypesTests` class to `private static`.
- Replaced `ExpressionNode expectedExpressionNode = new ExpressionNode("TEST-BODY", "TEST-TYPE")` with `ExpressionNode expectedExpressionNode = new("TEST-BODY", "TEST-TYPE")` in `ValueTests` class.
- Removed `[CallerMemberName]` attribute from `AsMoney` method in `ToMoney` class.
- Replaced `Number value;` and `string expressionName;` with `readonly Number value;` in `MoneyBuilder` class.
- Added `readonly` modifier to `SingleNumber` field and changed `MultipleNumbers` from `new()` to `[]` in `ValueCollectionWithAggregateMethodTests` class.
- Changed `GetResult` method in `ValueArgumentsSelectorTests` class to `private static`.
- Updated package references in `Fluent.Calculations.Primitives.Tests.csproj` and `Fluent.Calculations.DotNetGraph.Tests.csproj`.
- Added `IsPrimitive` property and updated `Get` property initialization in `ReturnValue` class.
- Updated namespace in `ArgumentsDebugView` class.
- Replaced `items = new List<IValue>()` with `items = []` in `ArgumentsCollection` class.
- Changed `CreateFrom` method in `ArgumentsCollection` class to use `new()` instead of `new ArgumentsCollection()`.
- Updated package references in `Fluent.Calculations.DotNetGraph.Tests.csproj`.
- Replaced `new Money(left.Add(right), left.Currency)` with `new(left.Add(right), left.Currency)` in `Money` class.
- Updated method names in `ConditionTests` class.
- Removed empty block in `GraphStyleMonochrome` class.
- Updated `CreateValueBlock` method in `GraphStyleMonochrome` class to `private static`.

> The following files were skipped due to too many changes: `src/Fluent.Calculations.DotNetGraph/Styles/GraphStyleMonochrome.cs`, `src/Fluent.Calculations.DotNetGraph/DotGraphValueBuilder.cs`, `src/Fluent.Calculations.Primitives.Tests/Expressions/MemberExpressionValueCapturerTests.cs`, `src/Fluent.Calculations.Primitives.Tests/Expressions/MemberExpressionsCapturerTests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->